### PR TITLE
Enable/disable template extensions (e.g. Appsody)

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -952,7 +952,7 @@ paths:
           description: Bad request
   /api/v1/batch/templates/repositories:
     patch:
-      summary: Batch change settings for a template repository of which Codewind is aware
+      summary: Batch change settings for template repositories of which Codewind is aware
       requestBody:
         description: repository settings
         content:
@@ -980,6 +980,48 @@ paths:
                       $ref: '#/components/schemas/TemplateRepoSetting'
                     error:
                       type: string
+  /api/v1/batch/templates/extensions:
+    patch:
+      summary: Batch change settings for template extensions of which Codewind is aware
+      requestBody:
+        description: extension settings
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemplateExtensionSetting'
+      responses:
+        207:
+          description: Returns success/failure statuses of settings operations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - status
+                    - requestedOperation
+                  properties:
+                    status:
+                      type: integer
+                    requestedOperation:
+                      $ref: '#/components/schemas/TemplateExtensionSetting'
+                    error:
+                      type: string
+  /api/v1/templates/extensions:
+    get:
+      summary: List all template extensions of which Codewind is aware
+      responses:
+        200:
+          description: Returns all the extensions that Codewind will use to find templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TemplateExtension'
   /api/v1/templates/styles:
     get:
       summary: List all project styles for which Codewind has templates
@@ -1368,6 +1410,18 @@ components:
           type: string
         enabled:
           type: boolean
+    TemplateExtension:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
     TemplateRepoSetting:
       type: object
       required:
@@ -1383,6 +1437,24 @@ components:
           description: url of the modified template repository
           type: string
           example: https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json
+        value:
+          type: string
+          example: 'true'
+    TemplateExtensionSetting:
+      type: object
+      required:
+        - op
+        - name
+        - value
+      properties:
+        op:
+          description: extension setting to change
+          type: string
+          enum: [enable]
+        name:
+          description: name of the modified template extension
+          type: string
+          example: AppsodyExtension
         value:
           type: string
           example: 'true'

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -31,49 +31,49 @@ module.exports = class ExtensionList {
   constructor() {
     this._list = {};
   }
-  
+
   /**
    * Install (unzip) built-in extensions that are stored in /extensions to the
    * given target directory
-   * 
-   * @param {string} targetDir, the target directory to install extensions to 
+   *
+   * @param {string} targetDir, the target directory to install extensions to
    */
   async installBuiltInExtensions(targetDir) {
-  
+
     // get the zips from the /extensions directory
     const entries = await fs.readdir(extensionsDir, { withFileTypes: true });
-    
+
     for (let entry of entries) {
-      
-        let match;
-  
-        // look for files with names matching the expected pattern
-        if (entry.isFile() && (match = extensionsPattern.exec(entry.name))) {
-          
-          const name = match[1];
-          const version = match[2];
+      this.hi = 1;
+      let match;
 
-          const source = path.join(extensionsDir, entry.name);
-          const target = path.join(targetDir, name);
-          const targetWithVersion = target + version;
+      // look for files with names matching the expected pattern
+      if (entry.isFile() && (match = extensionsPattern.exec(entry.name))) {
 
-          try {
-            await prepForUnzip(target);
-            await exec(`unzip ${source} -d ${targetDir}`);
+        const name = match[1];
+        const version = match[2];
 
-            // top-level directory in zip will have the version suffix
-            // rename to remove the version
-            await fs.rename(targetWithVersion, target);
-          }
-          catch (err) {
-            log.warn(`Failed to install ${entry.name}`);
-            log.warn(err);
-          }
-          finally {
-            // to be safe, try to remove directory with version name if it still exist
-            await forceRemove(targetWithVersion);
-          }
+        const source = path.join(extensionsDir, entry.name);
+        const target = path.join(targetDir, name);
+        const targetWithVersion = target + version;
+
+        try {
+          await prepForUnzip(target);
+          await exec(`unzip ${source} -d ${targetDir}`);
+
+          // top-level directory in zip will have the version suffix
+          // rename to remove the version
+          await fs.rename(targetWithVersion, target);
         }
+        catch (err) {
+          log.warn(`Failed to install ${entry.name}`);
+          log.warn(err);
+        }
+        finally {
+          // to be safe, try to remove directory with version name if it still exist
+          await forceRemove(targetWithVersion);
+        }
+      }
     }
   }
 
@@ -97,7 +97,7 @@ module.exports = class ExtensionList {
             if (extension.templates) {
               await templates.addRepository(extension.templates, extension.description);
             } else if (extension.templatesProvider) {
-              templates.addProvider(extension.name, extension.templatesProvider);
+              templates.addExtension(extension.name, extension.templatesProvider);
               delete extension.templatesProvider;
             }
           }
@@ -208,7 +208,7 @@ module.exports = class ExtensionList {
 
 /**
  * Force remove a path, regardless of whether it exists, or it's file or directory that may or may not be empty.
- * 
+ *
  * @param {string} path, path to remove
  */
 async function forceRemove(path) {
@@ -223,13 +223,13 @@ async function forceRemove(path) {
 /**
  * Prepare the directory where an extension will be unzipped to. If directory
  * exists with the same name, it will be renamed by appending the "__old" suffix to it.
- * 
+ *
  * @param {string} target, the target directory to unzip to
  */
 async function prepForUnzip(target) {
-  
+
   if (await utils.fileExists(target)) {
-  
+
     const targetOld = target + suffixOld;
 
     // try to remove previous backup that may or may not exist before rename

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -53,7 +53,7 @@ module.exports = class User {
     }
     this.secure = true;
   }
-  
+
   /**
    * Function to initialise a user
    * Runs functions to create the user directories, start existing projects
@@ -77,7 +77,7 @@ module.exports = class User {
       await this.initialiseExistingProjects();
 
       this.templates = new Templates(this.workspace);
-      await this.templates.initializeRepositoryList();
+      await this.templates.initialize();
 
       // Create the list of codewind extensions
       this.extensionList = new ExtensionList();

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -88,7 +88,15 @@ router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, re
   const user = req.cw_user;
   const templateController = user.templates;
   const requestedOperations = req.body;
-  const operationResults = await templateController.batchUpdate(requestedOperations);
+  const operationResults = await templateController.batchUpdateRepos(requestedOperations);
+  res.status(207).json(operationResults);
+});
+
+router.patch('/api/v1/batch/templates/extensions', validateReq, async (req, res) => {
+  const user = req.cw_user;
+  const templateController = user.templates;
+  const requestedOperations = req.body;
+  const operationResults = await templateController.batchUpdateExtensions(requestedOperations);
   res.status(207).json(operationResults);
 });
 
@@ -100,6 +108,18 @@ router.get('/api/v1/templates/styles', validateReq, async (req, res, _next) => {
   const templateController = user.templates;
   const styles = await templateController.getTemplateStyles();
   res.status(200).json(styles);
+});
+
+/**
+ * API Function to return a list of available template extensions
+ * @return {[JSON]}
+ */
+router.get('/api/v1/templates/extensions', validateReq, async (req, res, _next) => {
+  const user = req.cw_user;
+  const templateController = user.templates;
+
+  const extensions = await templateController.getTemplateExtensions();
+  res.status(200).json(extensions);
 });
 
 module.exports = router;


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

resolves https://github.com/eclipse/codewind/issues/ /279

Notes:
- the issue and the tests should explain how this works
- when template extensions (e.g. Appsody) are disabled, this setting is saved in the memory of the `Templates` instance, and written out to a `template_extension_settings.json`, so that if PFE is restarted, it can read that file and thus remember the setting
- In `Templates.js`, I renamed `providers` to `extensions`, to reduce the number of concepts in that file