### PR TITLE
turbine feat: modify Node dockerfile to reduce copying

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejsScripts/Dockerfile-dev-setup-nodejs
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/Dockerfile-dev-setup-nodejs
@@ -1,0 +1,16 @@
+
+#*******************************************************************************
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#*******************************************************************************
+
+# Copy the necessary scripts over
+COPY ./scripts/noderun.sh /scripts/noderun.sh
+
+RUN chmod -R +x /scripts


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Based this code on what we do in `spring-container.sh`, and if I restart the pod I do find `nodejsScripts` in the container, and `tail` is running, but no `node` process. So the app is not running. 

I can `exec` into the container and manually do `npm start`, which gets the app running. Then if I hit `Restart in Run mode` or `Restart in Debug mode`, the app stops and does not start the node process back up

I'm not sure why this is the case